### PR TITLE
`mc port` creates virtual ports

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,22 +15,26 @@ func main() {
 		fmt.Println("Usage: mc <command> [arguments]")
 		fmt.Println()
 		fmt.Println("Commands:")
-		fmt.Println("  fwd <input-port-name> <output-port-name>  Forward MIDI from input to output")
-		fmt.Println("  list                                      List available MIDI ports")
+		fmt.Println("  list                            List available MIDI ports")
+		fmt.Println("  fwd <input-name> <output-name>  Forward MIDI from input to output")
+		fmt.Println("  port <name>                     Open virtual port")
 		fmt.Println()
 		fmt.Println("Examples:")
-		fmt.Println("  mc fwd \"MIDI Device 1\" \"MIDI Device 2\"")
 		fmt.Println("  mc list")
+		fmt.Println("  mc fwd \"MIDI Device 1\" \"MIDI Device 2\"")
+		fmt.Println("  mc port mc-port")
 		os.Exit(1)
 	}
 
 	command := os.Args[1]
 
 	switch command {
-	case "fwd":
-		handleForwardCommand()
 	case "list":
 		listPorts()
+	case "fwd":
+		handleForwardCommand()
+	case "port":
+
 	default:
 		fmt.Printf("Unknown command: %s\n", command)
 		fmt.Println("Usage: mc <command> [arguments]")

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ func main() {
 		fmt.Println("Commands:")
 		fmt.Println("  list                            List available MIDI ports")
 		fmt.Println("  fwd <input-name> <output-name>  Forward MIDI from input to output")
-		fmt.Println("  port <name>                     Open virtual port")
+		fmt.Println("  port [name]                     Open virtual port (defaults to 'mc-port')")
 		fmt.Println()
 		fmt.Println("Examples:")
 		fmt.Println("  mc list")
 		fmt.Println("  mc fwd \"MIDI Device 1\" \"MIDI Device 2\"")
-		fmt.Println("  mc port mc-port")
+		fmt.Println("  mc port")
 		os.Exit(1)
 	}
 
@@ -34,7 +34,7 @@ func main() {
 	case "fwd":
 		handleForwardCommand()
 	case "port":
-
+		handlePortCommand()
 	default:
 		fmt.Printf("Unknown command: %s\n", command)
 		fmt.Println("Usage: mc <command> [arguments]")
@@ -75,5 +75,36 @@ func handleForwardCommand() {
 	// Start forwarding
 	if err := forwarder.Start(ctx); err != nil {
 		log.Fatalf("Error during MIDI forwarding: %v", err)
+	}
+}
+
+func handlePortCommand() {
+	// Set default port name if none provided
+	portName := "mc-port"
+
+	// Check if a custom port name was provided
+	if len(os.Args) >= 3 {
+		portName = os.Args[2]
+	}
+
+	// Create virtual MIDI port
+	virtualPort, err := NewVirtualPort(portName)
+	if err != nil {
+		log.Fatalf("Failed to create virtual MIDI port: %v", err)
+	}
+
+	defer virtualPort.cancel()
+
+	// Handle graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		virtualPort.cancel()
+	}()
+
+	// Start virtual port
+	if err := virtualPort.Start(); err != nil {
+		log.Fatalf("Error during virtual port operation: %v", err)
 	}
 }

--- a/port.go
+++ b/port.go
@@ -1,0 +1,1 @@
+package main

--- a/port.go
+++ b/port.go
@@ -1,1 +1,73 @@
 package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"gitlab.com/gomidi/midi/v2/drivers"
+	"gitlab.com/gomidi/midi/v2/drivers/rtmididrv"
+)
+
+type VirtualPort struct {
+	name    string
+	inPort  drivers.In
+	outPort drivers.Out
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
+func NewVirtualPort(name string) (*VirtualPort, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	driver, ok := drivers.Get().(*rtmididrv.Driver)
+	if !ok {
+		cancel() // Cancel context on error
+		return nil, fmt.Errorf("rtmididrv driver not available")
+	}
+
+	// Create virtual input port (for receiving MIDI from other applications)
+	inPort, err := driver.OpenVirtualIn(name)
+	if err != nil {
+		cancel() // Cancel context on error
+		return nil, fmt.Errorf("failed to create virtual MIDI input port '%s': %w", name, err)
+	}
+
+	// Create virtual output port (for sending MIDI to other applications)
+	outPort, err := driver.OpenVirtualOut(name)
+	if err != nil {
+		cancel()       // Cancel context on error
+		inPort.Close() // Clean up input port
+		return nil, fmt.Errorf("failed to create virtual MIDI output port '%s': %w", name, err)
+	}
+
+	return &VirtualPort{
+		name:    name,
+		inPort:  inPort,
+		outPort: outPort,
+		ctx:     ctx,
+		cancel:  cancel,
+	}, nil
+}
+
+func (vp *VirtualPort) Start() error {
+	stopFn, err := vp.inPort.Listen(func(msg []byte, timestampms int32) {
+		if err := vp.outPort.Send(msg); err != nil {
+			log.Printf("Error sending to %q output: %v", msg, err)
+		}
+	}, drivers.ListenConfig{
+		TimeCode: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start listening on input port: %w", err)
+	}
+	defer stopFn()
+
+	log.Printf("Virtual MIDI port '%s' is now available", vp.name)
+
+	// Wait for context cancellation
+	<-vp.ctx.Done()
+
+	log.Printf("Closing virtual MIDI port '%s'...", vp.name)
+	return nil
+}


### PR DESCRIPTION
Provides similar functionality as Audio MIDI Setup's IAC Driver for sending MIDI messages between applications ([docs](https://support.apple.com/guide/audio-midi-setup/transfer-midi-information-between-apps-ams1013/mac)).

Was hoping this approach might incur less latency, but so far no luck.